### PR TITLE
puma起動時にエラーになる現象を回避

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,7 +36,5 @@ pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 #
 preload_app!
 
-rackup DefaultRackup
-
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
```
teruo.kakikubo@QCPF6X4PQY ~/Documents/jwt-api % dip rails s
[+] Running 1/0
 ⠿ Container jwt-api-db-1  Running                                                                                                                                                           0.0s
=> Booting Puma
=> Rails 7.0.4 application starting in development
=> Run `bin/rails server --help` for more startup options
Exiting
config/puma.rb:39:in `_load_from': uninitialized constant Puma::DSL::DefaultRackup (NameError)

rackup DefaultRackup
       ^^^^^^^^^^^^^
        from /usr/local/bundle/gems/puma-6.0.0/lib/puma/dsl.rb:131:in `instance_eval'
        from /usr/local/bundle/gems/puma-6.0.0/lib/puma/dsl.rb:131:in `_load_from'
        from /usr/local/bundle/gems/puma-6.0.0/lib/puma/configuration.rb:235:in `block in load'
        from /usr/local/bundle/gems/puma-6.0.0/lib/puma/configuration.rb:235:in `each'
        from /usr/local/bundle/gems/puma-6.0.0/lib/puma/configuration.rb:235:in `load'
        from /usr/local/bundle/gems/puma-6.0.0/lib/puma/launcher.rb:54:in `initialize'
        from /usr/local/bundle/gems/puma-6.0.0/lib/rack/handler/puma.rb:68:in `new'
        from /usr/local/bundle/gems/puma-6.0.0/lib/rack/handler/puma.rb:68:in `run'
        from /usr/local/bundle/gems/rack-2.2.4/lib/rack/server.rb:327:in `start'
        from /usr/local/bundle/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:38:in `start'
        from /usr/local/bundle/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:143:in `block in perform'
        from <internal:kernel>:90:in `tap'
        from /usr/local/bundle/gems/railties-7.0.4/lib/rails/commands/server/server_command.rb:134:in `perform'
        from /usr/local/bundle/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
        from /usr/local/bundle/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /usr/local/bundle/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
        from /usr/local/bundle/gems/railties-7.0.4/lib/rails/command/base.rb:87:in `perform'
        from /usr/local/bundle/gems/railties-7.0.4/lib/rails/command.rb:48:in `invoke'
        from /usr/local/bundle/gems/railties-7.0.4/lib/rails/commands.rb:18:in `<main>'
        from /usr/local/bundle/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from /usr/local/bundle/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
        from bin/rails:6:in `<main>'
```

こんな感じでエラーになっていたので該当行を削除する事にした。
元ネタはこちら(随分古いけど)
https://github.com/puma/puma/issues/683#issuecomment-91920381