### PR TITLE
WARN[0000] /Users/teruo.kakikubo/Documents/kakikubo/jwt-api/docker-co…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
 # composeファイルのバージョン指定
 # https://docs.docker.com/compose/compose-file/compose-versioning/
-version: "3.8"
-
 services:
   # サービス（コンテナ）
   db:


### PR DESCRIPTION
…mpose.yml: `version` is obsolete

```
WARN[0000] /Users/teruo.kakikubo/Documents/kakikubo/jwt-api/docker-compose.yml: `version` is obsolete
```

不要な指定をdocker-compose.ymlから除外した
