### PR TITLE
refactor: AuthTokenControllerをサービスクラスに分離してリファクタリング

### DIFF
--- a/app/services/auth_response_builder.rb
+++ b/app/services/auth_response_builder.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# 認証レスポンスの構築を担当するサービス
+class AuthResponseBuilder
+  attr_reader :user, :token_service
+
+  def initialize(user, token_service = nil)
+    @user = user
+    @token_service = token_service || AuthTokenService.new(user)
+  end
+
+  # ログイン成功時のレスポンスを構築
+  def build_login_response
+    access_token_data = token_service.access_token_data
+
+    {
+      token: access_token_data[:token],
+      expires: access_token_data[:expires],
+      user: user.response_json(sub: access_token_data[:subject])
+    }
+  end
+
+  # エラーレスポンスを構築
+  def build_error_response(status_code, message)
+    {
+      status: status_code,
+      error: message
+    }
+  end
+
+  # JTIエラー時の特定レスポンス
+  def build_invalid_jti_response
+    build_error_response(401, 'Invalid jti for refresh token')
+  end
+end

--- a/app/services/auth_token_service.rb
+++ b/app/services/auth_token_service.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# JWT認証トークンの生成と管理を担当するサービス
+class AuthTokenService
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  # アクセストークンとリフレッシュトークンのペアを生成
+  def generate_token_pair
+    {
+      access_token: access_token_data,
+      refresh_token: refresh_token_data
+    }
+  end
+
+  # アクセストークンの情報を取得
+  def access_token_data
+    token_instance = encoded_access_token
+    {
+      token: token_instance.token,
+      expires: token_instance.payload[:exp],
+      subject: token_instance.payload[:sub]
+    }
+  end
+
+  # リフレッシュトークンの情報を取得
+  def refresh_token_data
+    token_instance = encoded_refresh_token
+    {
+      token: token_instance.token,
+      expires: Time.at(token_instance.payload[:exp])
+    }
+  end
+
+  # リフレッシュトークンをCookieに設定するためのオプションを生成
+  def refresh_token_cookie_options
+    refresh_data = refresh_token_data
+    {
+      value: refresh_data[:token],
+      expires: refresh_data[:expires],
+      secure: Rails.env.production?,
+      http_only: true
+    }
+  end
+
+  private
+
+  # アクセストークンのエンコード済みインスタンス（メモ化）
+  def encoded_access_token
+    @encoded_access_token ||= user.encode_access_token
+  end
+
+  # リフレッシュトークンのエンコード済みインスタンス（メモ化）
+  def encoded_refresh_token
+    @encoded_refresh_token ||= user.encode_refresh_token
+  end
+end


### PR DESCRIPTION
## Summary

AuthTokenControllerの責務を整理し、JWT認証トークンの処理をサービスクラスに分離するリファクタリングを実施しました。

### 主な変更内容

- **AuthTokenService**の新規作成
  - JWT認証トークン（アクセストークン・リフレッシュトークン）の生成と管理を担当
  - トークンデータの取得、Cookieオプションの生成を提供
  
- **AuthResponseBuilder**の新規作成
  - 認証レスポンスの構築を担当
  - ログイン成功レスポンス、エラーレスポンスの統一的な構築

- **AuthTokenController**のリファクタリング
  - トークン生成とレスポンス構築の処理を各サービスクラスに委譲
  - コントローラーの責務をルーティングとHTTP処理に集約
  - 重複していたプライベートメソッドを削除

### 利点

- **単一責任原則の適用**: 各クラスが明確な責務を持つように整理
- **テスタビリティの向上**: サービスクラス単体でのテストが可能
- **保守性の向上**: 認証ロジックの変更時の影響範囲を限定
- **再利用性**: サービスクラスを他の場所でも利用可能

## Test plan

- [ ] 既存のテストがすべてパスすることを確認
- [ ] 新しいサービスクラスのユニットテストを追加（必要に応じて）
- [ ] 認証フローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)