### PR TITLE
docs: add Claude Code skills for Rails backend and Nuxt frontend

### DIFF
--- a/.claude/skills/nuxt-frontend/SKILL.md
+++ b/.claude/skills/nuxt-frontend/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: nuxt-frontend
+description: "jwt-apiリポジトリの front/ ディレクトリ配下にあるNuxt 4フロントエンドアプリケーションでの開発ガイド。Vue 3 / TypeScript / Vuetify 4 / Pinia / Biome / pnpmを使用。認証ミドルウェアチェーン、Piniaストア、useApi composable、i18n対応などフロントエンド作業時に参照する。Nuxt, Vue, Vuetify, Pinia, Biome, pnpm, useApi, silent-refresh-token, authentication middleware などのキーワードで呼び出す。"
+---
+
+# Nuxt フロントエンド開発ガイド
+
+## 技術スタック
+
+- Nuxt 4 / Vue 3 / TypeScript (strictモード)
+- Vuetify 4 / Pinia
+- Biome（lint・format）
+- pnpm（パッケージマネージャー）
+- i18n対応（日本語/英語、デフォルト日本語）
+
+## 作業ディレクトリ
+
+**必ず `front/` ディレクトリに移動して作業する**。リポジトリルートではなく `front/` 配下に `pages/`, `components/`, `composables/`, `middleware/`, `stores/`, `layouts/`, `plugins/`, `server/`, `utils/`, `locales/`, `types/` などが配置されている。
+
+```bash
+cd front
+```
+
+## よく使うコマンド
+
+```bash
+cd front
+pnpm install    # 依存パッケージインストール
+pnpm dev        # 開発サーバー起動（http://localhost:3000）
+pnpm build      # ビルド
+pnpm lint       # Lint確認（Biome）
+pnpm lint:fix   # Lint自動修正
+```
+
+## アーキテクチャ
+
+### ミドルウェアチェーン（実行順序が重要）
+
+`front/middleware/` 配下に以下の順で実行される:
+
+1. **`silent-refresh-token`** - 期限切れトークンの自動リフレッシュ（認証チェック**前**に実行）
+2. **`authentication`** - 認証チェック、未認証時はログインへリダイレクト
+3. **`logged-in-redirect`** - 認証済みユーザーをログイン/サインアップページからリダイレクト
+
+ミドルウェアを追加・変更する際はこの実行順序を崩さないこと。
+
+### useApi composable
+
+`front/composables/useApi.ts` はAPIクライアント。401レスポンス時に自動でトークンリフレッシュを試行する。バックエンドと通信する際は生の `$fetch` ではなくこちらを使用する。
+
+### Piniaストア
+
+`front/stores/` 配下:
+
+| ストア | 役割 |
+|-----|-----|
+| `useAuthStore` | トークン・有効期限・JWTペイロード管理 |
+| `useUserStore` | ユーザー情報 |
+| `useProjectStore` | プロジェクト一覧 |
+| `useToastStore` | トースト通知キュー |
+| `useAppStore` | ナビゲーション状態（認証失敗時のリダイレクト先記憶） |
+
+### バックエンドとの連携
+
+- 全リクエストに `X-Requested-With: XMLHttpRequest` ヘッダー必須（CSRF対策）
+- リフレッシュトークンはHttpOnly Cookieで送受信されるため `credentials: 'include'` が必要
+- 認証エンドポイント: `POST /api/v1/auth_token`, `POST /api/v1/auth_token/refresh`, `DELETE /api/v1/auth_token`
+
+## コーディング規約
+
+- **Biome**（`front/biome.jsonc`）でリント・フォーマット
+  - シングルクォート
+  - 行幅80
+- **TypeScript strictモード**有効
+- i18nはデフォルト日本語、翻訳は `front/locales/` で管理
+
+## 検証手順
+
+コード変更後は以下を実行:
+
+1. `cd front && pnpm lint` で静的解析
+2. UI/フロントエンド変更時は `pnpm dev` で開発サーバーを起動し、ブラウザで実際に機能を操作して確認
+3. ゴールデンパスとエッジケースの両方を確認し、他機能にリグレッションがないか監視
+4. 型チェック・テストはコードの正しさを検証するが**機能の正しさ**は検証しない。UIを実際に確認できない場合はその旨を明示する
+
+## Docker環境
+
+- ポート: Frontend `3000`, API `33000`, DB `25432`
+- API通信先は環境変数で制御（`front/.envrc` 参照）

--- a/.claude/skills/rails-backend/SKILL.md
+++ b/.claude/skills/rails-backend/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: rails-backend
+description: "jwt-apiリポジトリのRails 8.1 APIバックエンドでの開発ガイド。JWT認証（Dual-Tokenパターン）、サービス層Mixin、RSpecテスト、RuboCopなどバックエンド側のコーディング・テスト・デバッグ作業時に参照する。Rails, RSpec, RuboCop, JWT, AuthToken, UserAuth, dip, Brakeman などのキーワードで呼び出す。"
+---
+
+# Rails バックエンド開発ガイド
+
+## 技術スタック
+
+- Ruby 4.0.0 / Rails 8.1（APIモード）
+- PostgreSQL 18.x / Puma 7.x
+- Docker / Docker Compose / dip
+
+## 作業ディレクトリ
+
+リポジトリルート（`/`配下）で作業する。`app/`, `config/`, `spec/` などRails標準構成。
+
+## よく使うコマンド
+
+Docker環境（dip）を優先的に使用する。
+
+```bash
+# テスト
+dip rspec                                              # 全体
+dip rspec spec/models                                  # ディレクトリ
+dip rspec spec/requests/api/v1/auth_token_controller_spec.rb  # 単体
+
+# Lint / セキュリティ
+dip rubocop            # 確認
+dip rubocop -A         # 自動修正
+dip brakeman           # セキュリティスキャン
+
+# Rails
+dip rails c            # コンソール
+dip rails db:migrate   # マイグレーション
+dip provision          # DB作成・マイグレーション・シード一括
+
+# Docker環境なしの場合のフォールバック
+bundle exec rspec
+bundle exec rubocop
+```
+
+## アーキテクチャ
+
+### JWT認証フロー（Dual-Tokenパターン）
+
+- **アクセストークン:** 有効期限30分、`Authorization`ヘッダーで送信、Rails MessageEncryptorで暗号化されたuser_id（subject）
+- **リフレッシュトークン:** 有効期限24時間、HttpOnly Cookieに格納、jti（JWT ID）でサーバー側検証（Userテーブルの`refresh_jti`カラム）
+- トークンクラス: `UserAuth::AccessToken`, `UserAuth::RefreshToken`, `UserAuth::TokenCommons`
+- セキュリティ原則: user_idは平文ではなく暗号化して格納。リフレッシュトークンはJTIのサーバー側照合でリプレイ攻撃を防止
+
+### サービス層（Mixinパターン）
+
+サービスはモジュールとしてコントローラーに `include` される:
+
+| モジュール | 役割 |
+|-----|-----|
+| `AuthTokenService` | トークンペアの生成とCookieシリアライズ |
+| `AuthResponseBuilder` | トークン＋ユーザーデータのレスポンス構築 |
+| `TokenGenerateService` | トークンのエンコード（Userモデルにinclude） |
+| `UserAuthenticateService` | アクセストークン検証（Authorizationヘッダーから） |
+| `UserSessionizeService` | リフレッシュトークン検証（Cookieから） |
+
+### APIエンドポイント
+
+- `POST /api/v1/auth_token` - ログイン（トークン発行）
+- `POST /api/v1/auth_token/refresh` - トークンリフレッシュ
+- `DELETE /api/v1/auth_token` - ログアウト（トークン破棄）
+- `GET /api/v1/projects` - プロジェクト一覧
+- 全リクエストに `X-Requested-With: XMLHttpRequest` ヘッダー必須（CSRF対策）
+
+## コーディング規約
+
+- 全Rubyファイルの先頭に `# frozen_string_literal: true` を記載
+- RuboCop設定: `.rubocop.yml`（`rubocop-rails`, `rubocop-rspec` 有効）
+- RSpecのコンテキスト名は**日本語**を使用（例: `context 'の場合'`, `context 'する場合'`）
+- コメントは日本語可
+- コミットメッセージに `Co-Authored-By` 行は**含めない**
+
+## 検証手順
+
+コード変更後は必ず以下を実行:
+
+1. `dip rubocop` で静的解析
+2. `dip rspec <関連スペック>` でテスト実行
+3. 認証・認可に関わる変更は `dip brakeman` を追加実行
+
+ログを確認し、動作を証明できるまで完了としない。
+
+## CI/CD
+
+- GitHub Actionsでプルリクエスト時にRuboCop + RSpecを自動実行
+- SimpleCovでカバレッジ計測、Codecovにアップロード
+- Herokuへデプロイ（`heroku.yml`で設定）
+
+## Docker環境
+
+- ポートマッピング: API `33000`, Frontend `3000`, DB `25432`
+- CORS: `credentials: true`（HttpOnly Cookie送受信のため）


### PR DESCRIPTION
## Summary
- Rails 8.1 APIバックエンド用スキル `rails-backend` を追加（JWT認証、サービス層Mixin、dip/RSpec/RuboCop/Brakemanコマンドなど）
- `front/` 配下のNuxt 4アプリ用スキル `nuxt-frontend` を追加（ミドルウェアチェーン、Piniaストア、useApi、Biome/pnpmなど）
- 作業ディレクトリが異なる（リポジトリルート vs `front/`）ため役割別に分割し、各スキルの `description` に呼び出しトリガーとなるキーワードを明記

## Test plan
- [ ] `.claude/skills/rails-backend/SKILL.md` がフロントマター付きで読めること
- [ ] `.claude/skills/nuxt-frontend/SKILL.md` がフロントマター付きで読めること
- [ ] Claude Codeセッションで両スキルが認識・呼び出し可能であること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Nuxt 4フロントエンド開発ガイドを追加（開発セットアップ、コマンド、ストア構成、API通信要件を記載）
  * Rails 8.1バックエンド開発ガイドを追加（開発セットアップ、コマンド、JWT認証パターン、API要件を記載）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->