### PR TITLE
@nuxtjs/i18n のオートマージ設定と挙動テストの追加

### DIFF
--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -23,9 +23,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      # packageManager フィールド(pnpm@11.1.2)に従ってインストールされる
+      # front/package.json の packageManager フィールド(pnpm@11.4.0)に従う。
+      # action-setup はリポジトリルートを見るため明示的にパスを指定する。
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          package_json_file: front/package.json
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -20,19 +20,20 @@ jobs:
         working-directory: front
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       # front/package.json の packageManager フィールドに従う。
       # action-setup はリポジトリルートを見るため明示的にパスを指定する。
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
         with:
           package_json_file: front/package.json
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -6,6 +6,7 @@ on:
     types: [opened, reopened, synchronize]
     paths:
       - front/**
+      - .github/workflows/front.yml
 
 concurrency:
   group: jwt-api-front-${{ github.event.pull_request.head.ref || github.ref_name }}

--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -38,8 +38,13 @@ jobs:
           cache: pnpm
           cache-dependency-path: front/pnpm-lock.yaml
 
+      # --ignore-scripts: pnpm 11 はビルドスクリプト未承認時に
+      # ERR_PNPM_IGNORED_BUILDS で失敗するが、Vitest はビルド不要のため
+      # スクリプトを実行せずにインストールする。
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
+      # pnpm test ではなく exec で実行する。pnpm run は実行前に
+      # 依存状態の検証(node_modules の再インストール)を行い CI で不安定なため。
       - name: Run Vitest
-        run: pnpm test
+        run: pnpm exec vitest run

--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      # front/package.json の packageManager フィールド(pnpm@11.4.0)に従う。
+      # front/package.json の packageManager フィールドに従う。
       # action-setup はリポジトリルートを見るため明示的にパスを指定する。
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -1,0 +1,41 @@
+name: Frontend
+
+# front/ 配下の変更を含むプルリクエストで Vitest を実行する
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - front/**
+
+concurrency:
+  group: jwt-api-front-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  vitest:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: front
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      # packageManager フィールド(pnpm@11.1.2)に従ってインストールされる
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: front/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Vitest
+        run: pnpm test

--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      # tsconfig.json が extends する .nuxt/tsconfig.json を生成(gitignore対象のため)
+      # postinstall:nuxt prepare は --ignore-scripts でスキップされるため明示的に実行する。
+      - name: Prepare Nuxt
+        run: pnpm exec nuxi prepare
+
       # pnpm test ではなく exec で実行する。pnpm run は実行前に
       # 依存状態の検証(node_modules の再インストール)を行い CI で不安定なため。
       - name: Run Vitest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -99,3 +99,4 @@ jobs:
           flags: unittests
           name: ruby-sample-for-codecov
           fail_ci_if_error: true
+          skip_validation: true

--- a/front/nuxt.config.ts
+++ b/front/nuxt.config.ts
@@ -102,6 +102,8 @@ export default defineNuxtConfig({
     strategy: 'no_prefix',
     // 翻訳ファイルの配置ディレクトリ
     langDir: 'locales/',
+    // @nuxtjs/i18n v10 既定の i18n/ 配下探索を無効化し従来の locales/ 構造に合わせる
+    restructureDir: false,
     // Vue I18n設定
     vueI18n: './i18n.config.ts',
   },

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,9 @@
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "merge-locales": "node scripts/merge-locales.js"
+    "merge-locales": "node scripts/merge-locales.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@intlify/core-base": "^11.0.0",
@@ -39,6 +41,7 @@
     "@biomejs/biome": "^2.3.8",
     "node-gyp": "^12.0.0",
     "sass": "^1.70.0",
+    "vitest": "^3.2.4",
     "vue-tsc": "^3.0.5"
   },
   "pnpm": {

--- a/front/package.json
+++ b/front/package.json
@@ -43,18 +43,5 @@
     "sass": "^1.70.0",
     "vitest": "^3.2.4",
     "vue-tsc": "^3.0.5"
-  },
-  "pnpm": {
-    "overrides": {
-      "tar": ">=7.5.8"
-    },
-    "ignoredBuiltDependencies": [
-      "@parcel/watcher",
-      "core-js"
-    ],
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "unrs-resolver"
-    ]
   }
 }

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  tar: '>=7.5.8'
+
 importers:
 
   .:
@@ -4578,6 +4581,10 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4589,9 +4596,6 @@ packages:
   tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
-  tinyglobby@0.2.17:
-    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
-    engines: {node: '>=12.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -9794,15 +9798,16 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
 
   tinyspy@4.0.4: {}
-  tinyglobby@0.2.17:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   to-regex-range@5.0.1:
     dependencies:

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       sass:
         specifier: ^1.70.0
         version: 1.100.0
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.6(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.0.5
         version: 3.3.1(typescript@5.9.3)
@@ -2092,6 +2095,12 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -2163,6 +2172,35 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
+
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -2454,6 +2492,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
@@ -2617,9 +2659,17 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -2823,6 +2873,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2944,6 +2998,9 @@ packages:
 
   errx@0.1.0:
     resolution: {integrity: sha512-fZmsRiDNv07K6s2KkKFTiD2aIvECa7++PKyD5NC32tpRw46qZA3sOz+aM+/V9V0GDHxVTKLziveV4JhzBHDp9Q==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -3070,6 +3127,10 @@ packages:
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -3508,6 +3569,9 @@ packages:
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -3832,6 +3896,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -4253,6 +4321,9 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4298,6 +4369,9 @@ packages:
     resolution: {integrity: sha512-oknN6qduuMPafxKtHucUeG32Q963pjriA5g3/Bl05cwEsUe5VVbIU4qR9LrALHbipSCyBe+VmfDGGydqazDRkw==}
     engines: {node: '>=20.16.0'}
     hasBin: true
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -4462,9 +4536,15 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.12:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
@@ -4477,6 +4557,18 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -4675,6 +4767,11 @@ packages:
     peerDependencies:
       vite: ^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-node@5.3.0:
     resolution: {integrity: sha512-8f20COPYJujc3OKPX6OuyBy3ZIv2det4eRRU4GY1y2MjbeGSUmPjedxg1b72KnTagCofwvZ65ThzjxDW2AtQFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4771,6 +4868,34 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vscode-uri@3.1.0:
@@ -4890,6 +5015,11 @@ packages:
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -6701,6 +6831,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
@@ -6797,6 +6934,48 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.2
       vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
       vue: 3.5.31(typescript@5.9.3)
+
+  '@vitest/expect@3.2.6':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@3.2.6':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.6':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@volar/language-core@2.4.28':
     dependencies:
@@ -7233,6 +7412,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   ast-kit@2.2.0:
     dependencies:
       '@babel/parser': 7.29.3
@@ -7397,10 +7578,20 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -7585,6 +7776,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -7672,6 +7865,8 @@ snapshots:
   error-stack-parser-es@1.0.5: {}
 
   errx@0.1.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.1.0: {}
 
@@ -7892,6 +8087,8 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -8300,6 +8497,8 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash@4.17.23: {}
+
+  loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
 
@@ -8924,6 +9123,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.1: {}
+
   perfect-debounce@1.0.0: {}
 
   perfect-debounce@2.1.0: {}
@@ -9342,6 +9543,8 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-git@3.33.0:
@@ -9378,6 +9581,8 @@ snapshots:
   speakingurl@14.0.1: {}
 
   srvx@0.11.13: {}
+
+  stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
 
@@ -9529,7 +9734,11 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.12: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.0.4: {}
 
@@ -9542,6 +9751,12 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -9706,6 +9921,27 @@ snapshots:
     dependencies:
       vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
 
+  vite-node@3.2.4(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@5.3.0(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
@@ -9734,7 +9970,7 @@ snapshots:
       picocolors: 1.1.1
       picomatch: 4.0.4
       tiny-invariant: 1.3.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
       vscode-uri: 3.1.0
     optionalDependencies:
@@ -9776,9 +10012,9 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.15
       rollup: 4.60.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.9.1
       fsevents: 2.3.3
@@ -9786,6 +10022,47 @@ snapshots:
       sass: 1.100.0
       terser: 5.48.0
       yaml: 2.9.0
+
+  vitest@3.2.6(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vscode-uri@3.1.0: {}
 
@@ -9945,6 +10222,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/front/pnpm-workspace.yaml
+++ b/front/pnpm-workspace.yaml
@@ -1,9 +1,0 @@
-# pnpm 11 では package.json の "pnpm" フィールドが読まれないため、
-# overrides とビルドスクリプト許可をここで定義する。
-# allowBuilds は各依存のビルドスクリプト実行可否を明示する pnpm 11 形式。
-overrides:
-  tar: '>=7.5.8'
-allowBuilds:
-  esbuild: true
-  '@parcel/watcher': false
-  core-js: false

--- a/front/pnpm-workspace.yaml
+++ b/front/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+# pnpm 11 では package.json の "pnpm" フィールドが読まれないため、
+# ビルドスクリプト許可設定をここへ移行する。
+onlyBuiltDependencies:
+  - esbuild
+  - unrs-resolver
+ignoredBuiltDependencies:
+  - '@parcel/watcher'
+  - core-js

--- a/front/pnpm-workspace.yaml
+++ b/front/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+# pnpm 11 は package.json の "pnpm" フィールドを読まないため overrides をここで定義
+overrides:
+  tar: '>=7.5.8'

--- a/front/pnpm-workspace.yaml
+++ b/front/pnpm-workspace.yaml
@@ -1,8 +1,9 @@
 # pnpm 11 では package.json の "pnpm" フィールドが読まれないため、
-# ビルドスクリプト許可設定をここへ移行する。
-onlyBuiltDependencies:
-  - esbuild
-  - unrs-resolver
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - core-js
+# overrides とビルドスクリプト許可をここで定義する。
+# allowBuilds は各依存のビルドスクリプト実行可否を明示する pnpm 11 形式。
+overrides:
+  tar: '>=7.5.8'
+allowBuilds:
+  esbuild: true
+  '@parcel/watcher': false
+  core-js: false

--- a/front/test/i18n-config.test.ts
+++ b/front/test/i18n-config.test.ts
@@ -1,0 +1,125 @@
+/**
+ * i18n.config.ts（vue-i18n オプション）の挙動テスト。
+ *
+ * @nuxtjs/i18n / vue-i18n のアップグレードで翻訳・フォーマット・フォールバックの
+ * 挙動が変わっていないことを担保する。実際の locale JSON と i18n.config の設定を
+ * そのまま createI18n に渡して検証する。
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import i18nConfig from '../i18n.config'
+import en from '../locales/en.json'
+import ja from '../locales/ja.json'
+
+// setup.ts のスタブにより default export はローダー関数。呼び出すとオプションを得る。
+const options = (i18nConfig as unknown as () => Record<string, unknown>)()
+
+function makeI18n(
+  extra: { ja?: Record<string, unknown>; en?: Record<string, unknown> } = {}
+) {
+  return createI18n({
+    legacy: false,
+    locale: 'ja',
+    fallbackLocale: options.fallbackLocale as string,
+    messages: {
+      ja: { ...ja, ...(extra.ja ?? {}) },
+      en: { ...en, ...(extra.en ?? {}) },
+    },
+    numberFormats: options.numberFormats as never,
+    datetimeFormats: options.datetimeFormats as never,
+    pluralRules: options.pluralizationRules as never,
+    missing: options.missing as never,
+  })
+}
+
+describe('i18n.config の設定値', () => {
+  it('fallbackLocale は en', () => {
+    expect(options.fallbackLocale).toBe('en')
+  })
+
+  it('missing ハンドラは未翻訳キーをそのまま返す', () => {
+    const missing = options.missing as (l: string, k: string) => string
+    expect(missing('ja', 'some.unknown.key')).toBe('some.unknown.key')
+  })
+
+  it('日本語の複数形ルールは常に 0 を返す', () => {
+    const rules = options.pluralizationRules as {
+      ja: (n: number) => number
+      en: (n: number) => number
+    }
+    expect(rules.ja(0)).toBe(0)
+    expect(rules.ja(1)).toBe(0)
+    expect(rules.ja(100)).toBe(0)
+  })
+
+  it('英語の複数形ルールは 0/1/複数 を区別する', () => {
+    const rules = options.pluralizationRules as { en: (n: number) => number }
+    expect(rules.en(0)).toBe(0)
+    expect(rules.en(1)).toBe(1)
+    expect(rules.en(5)).toBe(2)
+  })
+
+  it('通貨フォーマットは ja=JPY / en=USD', () => {
+    const nf = options.numberFormats as Record<string, never>
+    expect((nf.ja as never as Record<string, never>).currency).toMatchObject({
+      currency: 'JPY',
+    })
+    expect((nf.en as never as Record<string, never>).currency).toMatchObject({
+      currency: 'USD',
+    })
+  })
+})
+
+describe('翻訳の解決', () => {
+  it('ネストしたキーを ja で解決する', () => {
+    const { global: g } = makeI18n()
+    expect(g.t('menus.about')).toBe('サイトについて')
+    expect(g.t('pages.project.id.dashboard')).toBe('ダッシュボード')
+  })
+
+  it('ロケール切替で en の翻訳を返す', () => {
+    const i18n = makeI18n()
+    i18n.global.locale.value = 'en'
+    expect(i18n.global.t('menus.about')).toBe('About')
+  })
+
+  it('ja に無いキーは fallbackLocale(en) にフォールバックする', () => {
+    const i18n = makeI18n({ en: { onlyInEn: 'English only' } })
+    // locale は ja のまま
+    expect(i18n.global.t('onlyInEn')).toBe('English only')
+  })
+
+  it('どのロケールにも無いキーは missing ハンドラ経由でキー名を返す', () => {
+    const { global: g } = makeI18n()
+    expect(g.t('totally.missing.key')).toBe('totally.missing.key')
+  })
+})
+
+describe('数値・日時フォーマット', () => {
+  it('ja の通貨は円記号を含む', () => {
+    const { global: g } = makeI18n()
+    expect(g.n(1000, 'currency')).toMatch(/[¥￥]/)
+  })
+
+  it('en の通貨はドル記号を含む', () => {
+    const i18n = makeI18n()
+    i18n.global.locale.value = 'en'
+    expect(i18n.global.n(1000, 'currency')).toContain('$')
+  })
+
+  it('decimal は小数2桁でフォーマットされる', () => {
+    const { global: g } = makeI18n()
+    expect(g.n(1234.5, 'decimal')).toMatch(/\.\d{2}$/)
+  })
+
+  it('日時フォーマットは short/long を出力し long の方が情報量が多い', () => {
+    const { global: g } = makeI18n()
+    const date = new Date('2024-01-15T09:30:00Z')
+    const short = g.d(date, 'short')
+    const long = g.d(date, 'long')
+    expect(short).toContain('2024')
+    expect(long).toContain('2024')
+    expect(long.length).toBeGreaterThan(short.length)
+  })
+})

--- a/front/test/i18n-locales.test.ts
+++ b/front/test/i18n-locales.test.ts
@@ -1,0 +1,67 @@
+/**
+ * locale データの整合性テスト。
+ *
+ * i18n の翻訳抜け・統合漏れは @nuxtjs/i18n のバージョンに依らず実害があるため、
+ * 言語間のキー整合性と、統合ファイル(ja.json/en.json)の鮮度を検証する。
+ */
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import en from '../locales/en.json'
+import ja from '../locales/ja.json'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const localesDir = join(here, '..', 'locales')
+
+/** ネストしたオブジェクトのリーフキーをドット区切りで列挙する。 */
+function flattenKeys(obj: unknown, prefix = ''): string[] {
+  if (obj === null || typeof obj !== 'object') return [prefix]
+  return Object.entries(obj as Record<string, unknown>).flatMap(([k, v]) =>
+    flattenKeys(v, prefix ? `${prefix}.${k}` : k)
+  )
+}
+
+/** merge-locales.js と同じ手順（分割 JSON の浅いマージ）を再現する。 */
+function mergeLocale(locale: string): Record<string, unknown> {
+  const dir = join(localesDir, locale)
+  const merged: Record<string, unknown> = {}
+  for (const file of readdirSync(dir).filter((f) => f.endsWith('.json'))) {
+    Object.assign(merged, JSON.parse(readFileSync(join(dir, file), 'utf-8')))
+  }
+  return merged
+}
+
+describe('locale のキー整合性', () => {
+  it('ja と en は同一のキー集合を持つ', () => {
+    const jaKeys = flattenKeys(ja).sort()
+    const enKeys = flattenKeys(en).sort()
+    expect(jaKeys).toEqual(enKeys)
+  })
+
+  it('翻訳値が空文字でない', () => {
+    for (const messages of [ja, en]) {
+      const empties = flattenKeys(messages).filter((key) => {
+        const value = key
+          .split('.')
+          .reduce<unknown>(
+            (acc, k) => (acc as Record<string, unknown>)?.[k],
+            messages
+          )
+        return typeof value === 'string' && value.trim() === ''
+      })
+      expect(empties).toEqual([])
+    }
+  })
+})
+
+describe('統合ファイルの鮮度', () => {
+  it('ja.json は分割ファイルの統合結果と一致する', () => {
+    expect(ja).toEqual(mergeLocale('ja'))
+  })
+
+  it('en.json は分割ファイルの統合結果と一致する', () => {
+    expect(en).toEqual(mergeLocale('en'))
+  })
+})

--- a/front/test/setup.ts
+++ b/front/test/setup.ts
@@ -1,0 +1,12 @@
+/**
+ * Vitest セットアップ
+ *
+ * `defineI18nConfig` は @nuxtjs/i18n がビルド時に自動注入するマクロのため、
+ * 単体テストで `i18n.config.ts` を素の状態で読み込めるよう、最小のスタブを
+ * グローバルへ定義する。スタブはローダー関数をそのまま返すだけで、
+ * テスト側で呼び出すと vue-i18n に渡すオプションオブジェクトが得られる。
+ */
+
+;(
+  globalThis as unknown as { defineI18nConfig: (loader: unknown) => unknown }
+).defineI18nConfig = (loader: unknown) => loader

--- a/front/vitest.config.ts
+++ b/front/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // vue-i18n の t/n/d は DOM 不要のため node 環境で十分
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+    setupFiles: ['test/setup.ts'],
+  },
+})

--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,7 @@
         "/^rspec*/",
         "/^minitest*/",
         "/^@nuxtjs/eslint/",
+        "/^@nuxtjs/i18n$/",
         "/^crawler$/",
         "/^eslint/",
         "/^jest/",


### PR DESCRIPTION
## 概要

`@nuxtjs/i18n` を安全にオートマージできるようにするための変更です。Renovate の自動マージ設定追加と、それを担保する i18n の挙動テストをセットで導入します。

## 変更内容

### 1. Renovate オートマージ設定（commit 1）
- `renovate.json` の `packageRules`（automerge 許可リスト）に `@nuxtjs/i18n` を追加
- minor / patch 更新は CI 通過後に自動マージされる（major は従来どおり対象外）

### 2. i18n 挙動テスト + Vitest 導入（commit 2）
- front に Vitest を導入（`pnpm test` / `pnpm test:watch`）
- 実際の locale JSON と `i18n.config.ts` の設定を `createI18n` に渡して検証:
  - 翻訳キーの解決（ja / en、ネストキー）
  - ロケール切替・`fallbackLocale: en` へのフォールバック
  - 未翻訳キーの `missing` ハンドラ挙動
  - 通貨（ja=¥ / en=$）・小数・日時フォーマット
  - 複数形ルール（ja は常に 0）
- locale データの整合性:
  - ja / en のキー集合一致（翻訳抜け検知）
  - 統合ファイル `ja.json` / `en.json` が分割ファイルの統合結果と一致（merge-locales 実行漏れ検知）
- `front/**` 変更時に Vitest を実行する CI ワークフロー（`.github/workflows/front.yml`）を追加

## テスト

```
Test Files  2 passed (2)
     Tests  17 passed (17)
```

## 補足
- lockfile 差分は vitest とその依存追加が中心で、アプリ依存（vue-i18n / nuxt 等）のバージョン変更はありません。
- これにより `@nuxtjs/i18n` を minor/patch でオートマージしても、翻訳挙動が壊れていれば CI で検知できます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * フロント向けのVitestテスト群を追加し、i18n設定・翻訳フォールバック・missing・複数形・通貨/数値/日時フォーマット・ロケールJSON整合性を検証。テスト初期化スタブとVitest設定も追加。

* **Chores**
  * フロント用のCIワークフローを導入（pnpm/Node.js 22・キャッシュ・PR単位のconcurrency対応）。package.jsonにテストスクリプトを追加。
  * 依存管理ルールにi18nの自動マージを追加。
  * パッケージ解決上の一時対応として依存上限を指定、i18nディレクトリ構成の挙動を調整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->