### PR TITLE
node-gyp の minor/patch 更新を auto-merge 対象に追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,6 +60,7 @@
         "/^crawler$/",
         "/^eslint/",
         "/^jest/",
+        "/^node-gyp$/",
         "/^ts-jest$/",
         "/^playwright/",
         "/^http-server$/",


### PR DESCRIPTION
## 概要

Renovate の auto-merge ルールに `node-gyp` を追加し、minor/patch 更新は CI 通過後に自動マージされるようにします。

PR #1152 (`node-gyp 12.3.0 → 12.4.0`) のような minor 更新を手動マージ不要にすることが目的です。

## 変更内容

- `renovate.json` の既存 auto-merge ルール（`matchUpdateTypes: ["minor", "patch"]`）の `matchPackageNames` に `/^node-gyp$/` を追加

## 動作

- **対象**: node-gyp の minor / patch 更新
- **major は除外**: ルールは minor/patch のみ対象のため、major は従来どおり手動マージ
- **CI 通過が条件**: `platformAutomerge: true` によりブランチ保護（必須チェック＝CI）が通過した場合のみマージ

```diff
         "/^jest/",
+        "/^node-gyp$/",
         "/^ts-jest$/",
```