### PR TITLE
Stoplight Elements で API 仕様書(OpenAPI)を HTML 化し GitHub Pages で公開

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -1,0 +1,96 @@
+name: API Doc
+
+# apidoc/ の OpenAPI 仕様書を Spectral で lint し、
+# develop への push で Stoplight Elements を GitHub Pages へ公開する。
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - apidoc/**
+      - .github/workflows/apidoc.yml
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - apidoc/**
+      - .github/workflows/apidoc.yml
+
+# GitHub Pages デプロイに必要な権限
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 同一ブランチの実行をまとめる。Pages デプロイの取りこぼしを防ぐため
+# push 時は cancel-in-progress を無効化する。
+concurrency:
+  group: jwt-api-apidoc-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+defaults:
+  run:
+    working-directory: apidoc
+
+jobs:
+  # Spectral による OpenAPI lint（PR・push 双方で実行）。失敗時は後続を停止する。
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Spectral lint
+        run: npm run lint
+
+  # develop への push のみ build → deploy を行う。
+  build:
+    needs: lint
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
+        with:
+          path: apidoc/dist
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -15,11 +15,10 @@ on:
       - apidoc/**
       - .github/workflows/apidoc.yml
 
-# GitHub Pages デプロイに必要な権限
+# 既定は最小権限（読み取りのみ）。Pages デプロイに必要な write 権限は
+# build / deploy ジョブに限定して付与する。
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # 同一ブランチの実行をまとめる。Pages デプロイの取りこぼしを防ぐため
 # push 時は cancel-in-progress を無効化する。
@@ -58,6 +57,10 @@ jobs:
     needs: lint
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -87,6 +90,9 @@ jobs:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.steering/20260610-apidoc-stoplight/design.md
+++ b/.steering/20260610-apidoc-stoplight/design.md
@@ -1,0 +1,61 @@
+# 設計: apidoc ミニプロジェクトと API 契約
+
+## ディレクトリ構成
+
+```
+apidoc/
+├── package.json        # 独立 npm プロジェクト（type: module）
+├── vite.config.ts      # base: '/jwt-api/'（GitHub Pages プロジェクトサイト）
+├── index.html          # <elements-api> を埋め込むエントリ HTML
+├── .spectral.yaml      # extends: spectral:oas
+├── .gitignore          # node_modules / dist
+├── README.md           # ローカル開発手順
+├── openapi.yaml        # 手書き OpenAPI 3.1 仕様書（lint 対象・正本）
+└── src/
+    ├── main.ts         # Elements web-components + styles を import、spec URL を注入
+    └── vite-env.d.ts   # vite/client 型参照
+```
+
+## 描画方式
+
+- `@stoplight/elements/web-components.min.js` を import して `<elements-api>` カスタム要素を登録（React セットアップ不要）
+- `openapi.yaml` は `?url` import で Vite のアセットとして emit し、`base` を考慮した正しい URL を `apiDescriptionUrl` 属性へ注入（正本を `apidoc/openapi.yaml` に保持したまま参照可能）
+- `router="hash"` で GitHub Pages のサブパス配信に対応
+
+## API 契約（ソースコードから抽出した実挙動）
+
+共通: 全リクエストに `X-Requested-With: XMLHttpRequest` 必須。欠如時は 403 `{ status, error: "Forbidden" }`（`ApplicationController#xhr_request?`）。
+
+### POST /api/v1/auth_token（ログイン / create）
+- Request body: `{ auth: { email, password } }`
+- 200: `{ token: string, expires: integer(unix epoch), user: { id, name } }` + `Set-Cookie: refresh_token`(HttpOnly)
+- 404: 認証失敗・非アクティブユーザー（ボディなし）
+
+### POST /api/v1/auth_token/refresh（リフレッシュ / collection）
+- 認証: `refresh_token` Cookie
+- 200: ログインと同一スキーマ + 新しい `refresh_token` Cookie
+- 401(ボディなし): セッション無効（`sessionize_user` → head :unauthorized）
+- 401(ボディあり): `{ status: 401, error: "Invalid jti for refresh token" }`（jti 不一致 = リプレイ検知）
+
+### DELETE /api/v1/auth_token/destroy（ログアウト / collection）
+- 認証: `refresh_token` Cookie
+- 200: ボディなし（Cookie 削除成功）
+- 401: セッション無効
+- 500: `{ status: 500, error: "Could not delete session" }`
+
+### GET /api/v1/projects（プロジェクト一覧 / index）
+- 認証: `Authorization: Bearer <access_token>`（暗号化 user_id を含むアクセストークン）
+- 200: `[{ id: integer, name: string, updatedAt: string(date-time) }]`
+- 401: 未認証 / 非アクティブ
+
+## securitySchemes
+
+- `bearerAuth`: http / bearer（暗号化アクセストークン）→ projects
+- `refreshCookie`: apiKey / in cookie / name `refresh_token` → refresh・destroy
+
+## CI/CD（.github/workflows/apidoc.yml）
+
+- `lint` ジョブ: PR・push 双方で Spectral oas lint（失敗で後続停止）
+- `build` ジョブ: `develop` push のみ。`npm install` → `npm run build` → configure-pages → upload-pages-artifact
+- `deploy` ジョブ: `develop` push のみ。deploy-pages（environment: github-pages）
+- アクションは既存規約に合わせ commit SHA で固定

--- a/.steering/20260610-apidoc-stoplight/requirements.md
+++ b/.steering/20260610-apidoc-stoplight/requirements.md
@@ -1,0 +1,32 @@
+# 要件: Stoplight Elements による API 仕様書(OpenAPI)公開
+
+出典: https://github.com/kaki-org/jwt-api/issues/1164
+
+## 目的
+
+手書きの OpenAPI 仕様書を Stoplight Elements で HTML 化し、GitHub Pages 上に常時最新の公開ドキュメントとして提供する。
+
+## 対象 API（全 4 エンドポイント）
+
+| メソッド | パス | 概要 |
+|----------|------|------|
+| POST | `/api/v1/auth_token` | ログイン（トークン発行） |
+| POST | `/api/v1/auth_token/refresh` | トークンリフレッシュ |
+| DELETE | `/api/v1/auth_token/destroy` | ログアウト |
+| GET | `/api/v1/projects` | プロジェクト一覧 |
+
+## 確定事項（Issue 設計判断より）
+
+- 生成元: 手書き YAML 1 ファイル（`apidoc/openapi.yaml`）
+- 描画: Stoplight Elements を npm でセルフホストバンドル（CDN 非依存）
+- ビルド: ルート直下に独立 Vite ミニプロジェクト `apidoc/`
+- デプロイ: GitHub Actions 公式（configure-pages + upload-pages-artifact + deploy-pages）、Pages ソース = GitHub Actions
+- トリガー: `develop` への push（`apidoc/**` パス変更時のみ）
+- 範囲: 全 4 エンドポイント + 認証詳細（securitySchemes、Cookie リフレッシュ、`X-Requested-With` 必須ヘッダ、req/res スキーマ）
+- 品質: デプロイ前に `@stoplight/spectral-cli` の oas lint を必須化（PR でも実行、エラー時はデプロイ停止）
+
+## 受け入れ条件
+
+1. `develop` への push で Spectral lint が通り、GitHub Pages に Stoplight Elements で描画された API ドキュメントが公開される
+2. 全 4 エンドポイントと認証スキームがドキュメント上で確認できる
+3. 仕様書に文法ミスがある場合、CI（Spectral）でデプロイが停止する

--- a/.steering/20260610-apidoc-stoplight/tasklist.md
+++ b/.steering/20260610-apidoc-stoplight/tasklist.md
@@ -28,7 +28,7 @@
 
 ### ローカルで検証済み
 - `openapi.yaml`・`apidoc.yml`・`package.json` の構文 OK
-- OpenAPI 内 7 件の `$ref` がすべて解決 OK
+- OpenAPI 内の `$ref`（ユニーク 7 種 / 延べ 16 箇所）がすべて解決 OK
 - `actionlint .github/workflows/apidoc.yml` PASS
 
 ### CI で実行（ローカル未実行の理由）

--- a/.steering/20260610-apidoc-stoplight/tasklist.md
+++ b/.steering/20260610-apidoc-stoplight/tasklist.md
@@ -1,0 +1,48 @@
+# タスクリスト: apidoc / Stoplight Elements
+
+- [x] `apidoc/` に独立 Vite プロジェクトを新設（`package.json` / `vite.config.ts`）
+- [x] `@stoplight/elements` を依存に追加しセルフホストでバンドル（`index.html` + `src/main.ts`）
+- [x] `apidoc/openapi.yaml` を手書きで作成
+  - [x] 4 エンドポイント全ての path / method / req / res スキーマ
+  - [x] securitySchemes: Bearer（暗号化アクセストークン）+ refresh トークン Cookie
+  - [x] `X-Requested-With: XMLHttpRequest` 必須ヘッダの記述
+- [x] `@stoplight/spectral-cli` を導入し oas ルールで lint（npm script 化 + `.spectral.yaml`）
+- [x] GitHub Actions ワークフロー追加（`.github/workflows/apidoc.yml`）
+  - [x] `develop` push（`apidoc/**` パス限定）でトリガー
+  - [x] Spectral lint ジョブ → 成功時のみ build → deploy-pages
+  - [x] PR でも lint を実行
+- [x] リポジトリ設定で Pages ソースを「GitHub Actions」に設定 → 手動手順を README に記載（リポジトリ設定変更は外部影響のため自動実行せず手順化）
+- [x] ローカル検証（YAML 構文 / `$ref` 解決 / actionlint）
+
+## 申し送り事項
+
+### 実装完了日
+2026-06-10
+
+### 計画と実績の差分
+- `/add-feature` ワークフローが参照する `steering` / `development-guidelines` /
+  `implementation-validator` スキルは本環境に存在しなかったため、軽量な計画ドキュメント作成と
+  自己レビューで代替した。
+- ビルド構成は `apidoc/openapi.yaml` を正本として保持しつつ、Vite の `?url` import で
+  アセット化する方式を採用（公開時も base 配下で正しく解決される）。
+
+### ローカルで検証済み
+- `openapi.yaml`・`apidoc.yml`・`package.json` の構文 OK
+- OpenAPI 内 7 件の `$ref` がすべて解決 OK
+- `actionlint .github/workflows/apidoc.yml` PASS
+
+### CI で実行（ローカル未実行の理由）
+- `npm install` / `npm run build` / `npm run lint`(Spectral) は npm レジストリが
+  サンドボックス外のためローカル実行不可。`.github/workflows/apidoc.yml` の lint ジョブ
+  （PR でも実行）で検証される。
+
+### 学んだこと
+- Stoplight Elements は `web-components.min.js` を import するだけで `<elements-api>`
+  カスタム要素を登録でき、React セットアップ不要でセルフホストできる。
+- GitHub Pages プロジェクトサイトは `base: '/<repo>/'` と `router="hash"` の組合せで
+  サブパス配信に対応する。
+
+### 次回への改善提案
+- npm レジストリにアクセスできる環境で `package-lock.json` を生成・コミットし、CI を
+  `npm ci` に切り替えると再現性が向上する。
+- 初回のみ必要な「Pages ソース = GitHub Actions」設定後、初回デプロイ URL を README へ反映する。

--- a/apidoc/.gitignore
+++ b/apidoc/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.local

--- a/apidoc/.spectral.yaml
+++ b/apidoc/.spectral.yaml
@@ -1,0 +1,2 @@
+extends:
+  - "spectral:oas"

--- a/apidoc/.spectral.yaml
+++ b/apidoc/.spectral.yaml
@@ -1,2 +1,30 @@
 extends:
   - "spectral:oas"
+
+# プロジェクト固有ルール。
+# 注: require-operation-security は追加しない。ログイン（POST /api/v1/auth_token）は
+# 認証不要の公開エンドポイントであり、全 operation に security を必須化すると誤検知するため。
+rules:
+  # 全 operation に X-Requested-With ヘッダパラメータ（CSRF 対策）が必須。
+  # CLAUDE.md 記載の「全リクエストに X-Requested-With: XMLHttpRequest が必要」を CI で担保する。
+  operation-requires-x-requested-with:
+    description: 全 operation に X-Requested-With ヘッダパラメータ（CSRF 対策）が必須
+    message: "{{path}} に X-Requested-With ヘッダパラメータがありません"
+    severity: error
+    given: "$.paths[*][get,put,post,delete,patch]"
+    then:
+      field: parameters
+      function: schema
+      functionOptions:
+        schema:
+          type: array
+          contains:
+            type: object
+            required:
+              - name
+              - in
+            properties:
+              name:
+                const: X-Requested-With
+              in:
+                const: header

--- a/apidoc/README.md
+++ b/apidoc/README.md
@@ -26,7 +26,8 @@ npm run lint     # Spectral で openapi.yaml を oas lint
 `.github/workflows/apidoc.yml` が以下を行う:
 
 1. **lint**（PR・push 双方）: `npm run lint`（Spectral）。失敗すると後続を停止。
-2. **build / deploy**（`develop` への push、`apidoc/**` 変更時のみ）: `npm run build` →
+2. **build / deploy**（`develop` への push かつ `apidoc/**` または
+   `.github/workflows/apidoc.yml` の変更時のみ）: `npm run build` →
    GitHub Pages 公式アクションで公開。
 
 ## リポジトリ設定（初回のみ）

--- a/apidoc/README.md
+++ b/apidoc/README.md
@@ -1,0 +1,45 @@
+# apidoc — jwt-api API ドキュメント
+
+手書きの OpenAPI 仕様書（`openapi.yaml`）を [Stoplight Elements](https://stoplight.io/open-source/elements) で描画し、GitHub Pages に公開する独立 Vite プロジェクト。
+
+公開 URL: https://kaki-org.github.io/jwt-api/
+
+## ローカル開発
+
+```bash
+cd apidoc
+npm install
+npm run dev      # http://localhost:5173/jwt-api/ で開発サーバー起動
+npm run build    # dist/ に静的ファイルを生成
+npm run preview  # ビルド結果をプレビュー
+npm run lint     # Spectral で openapi.yaml を oas lint
+```
+
+## 仕様書の編集
+
+- 正本は `openapi.yaml`（OpenAPI 3.1）の 1 ファイル。
+- 編集後は `npm run lint` で文法チェックを行う。Spectral の `spectral:oas` ルールに従う。
+- `@stoplight/elements` はセルフホストでバンドルしており CDN には依存しない。
+
+## デプロイ
+
+`.github/workflows/apidoc.yml` が以下を行う:
+
+1. **lint**（PR・push 双方）: `npm run lint`（Spectral）。失敗すると後続を停止。
+2. **build / deploy**（`develop` への push、`apidoc/**` 変更時のみ）: `npm run build` →
+   GitHub Pages 公式アクションで公開。
+
+## リポジトリ設定（初回のみ）
+
+GitHub のリポジトリ設定で Pages のソースを **GitHub Actions** に設定する必要がある:
+
+- Settings → Pages → Build and deployment → Source: **GitHub Actions**
+
+または gh CLI:
+
+```bash
+gh api -X POST repos/kaki-org/jwt-api/pages \
+  -f 'build_type=workflow' || \
+gh api -X PUT repos/kaki-org/jwt-api/pages \
+  -f 'build_type=workflow'
+```

--- a/apidoc/index.html
+++ b/apidoc/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>jwt-api API ドキュメント</title>
+  </head>
+  <body style="margin: 0; height: 100vh">
+    <!-- openapi.yaml の URL は src/main.ts が apiDescriptionUrl 属性へ注入する -->
+    <elements-api router="hash" layout="sidebar" tryItCredentialsPolicy="same-origin">
+    </elements-api>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apidoc/openapi.yaml
+++ b/apidoc/openapi.yaml
@@ -1,0 +1,296 @@
+openapi: 3.1.0
+info:
+  title: jwt-api API
+  version: 1.0.0
+  description: |
+    JWT 認証システムを備えた Rails API の仕様書。
+
+    ## 認証方式（Dual-Token パターン）
+
+    - **アクセストークン**: 有効期限 30 分。`Authorization: Bearer <token>` ヘッダで送信。
+      Rails MessageEncryptor で暗号化された `user_id`（subject）を含む。
+    - **リフレッシュトークン**: 有効期限 24 時間。HttpOnly Cookie（`refresh_token`）に格納。
+      jti（JWT ID）をサーバー側（`users.refresh_jti`）で照合し、リプレイ攻撃を防止する。
+
+    ## 共通の必須ヘッダ（CSRF 対策）
+
+    すべてのリクエストに `X-Requested-With: XMLHttpRequest` ヘッダが必要。
+    欠如している場合は `403 Forbidden` を返す。
+  contact:
+    name: kaki-org/jwt-api
+    url: https://github.com/kaki-org/jwt-api
+  license:
+    name: MIT
+
+servers:
+  - url: http://localhost:33000
+    description: ローカル開発環境（Docker）
+  - url: https://{host}
+    description: 本番環境
+    variables:
+      host:
+        default: example.herokuapp.com
+
+tags:
+  - name: Authentication
+    description: トークンの発行・更新・破棄
+  - name: Projects
+    description: プロジェクト一覧
+
+paths:
+  /api/v1/auth_token:
+    post:
+      tags:
+        - Authentication
+      summary: ログイン（トークン発行）
+      description: |
+        メールアドレスとパスワードで認証し、アクセストークンを発行する。
+        リフレッシュトークンは HttpOnly Cookie（`refresh_token`）として `Set-Cookie` で返却される。
+      operationId: createAuthToken
+      parameters:
+        - $ref: '#/components/parameters/XRequestedWith'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthRequest'
+      responses:
+        '200':
+          description: ログイン成功。アクセストークンとユーザー情報を返す。
+          headers:
+            Set-Cookie:
+              description: リフレッシュトークン（HttpOnly Cookie）
+              schema:
+                type: string
+              example: refresh_token=eyJhbGciOi...; path=/; HttpOnly
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: 認証失敗（資格情報不一致、または非アクティブユーザー）。ボディは空。
+
+  /api/v1/auth_token/refresh:
+    post:
+      tags:
+        - Authentication
+      summary: トークンリフレッシュ
+      description: |
+        HttpOnly Cookie の `refresh_token` を検証し、新しいアクセストークンを発行する。
+        新しいリフレッシュトークンが `Set-Cookie` で再発行される。
+        jti がサーバー側の値と一致しない場合（リプレイ検知）は `401` を返す。
+      operationId: refreshAuthToken
+      security:
+        - refreshCookie: []
+      parameters:
+        - $ref: '#/components/parameters/XRequestedWith'
+      responses:
+        '200':
+          description: リフレッシュ成功。ログインと同一のスキーマを返す。
+          headers:
+            Set-Cookie:
+              description: 再発行されたリフレッシュトークン（HttpOnly Cookie）
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '401':
+          description: |
+            セッション無効。次のいずれか:
+            - リフレッシュトークン Cookie が存在しない／復号できない（ボディは空）
+            - jti 不一致（リプレイ検知）。下記スキーマのエラーボディを返す。
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                status: 401
+                error: Invalid jti for refresh token
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/auth_token/destroy:
+    delete:
+      tags:
+        - Authentication
+      summary: ログアウト（トークン破棄）
+      description: |
+        サーバー側の `refresh_jti` を破棄し、リフレッシュトークン Cookie を削除する。
+      operationId: destroyAuthToken
+      security:
+        - refreshCookie: []
+      parameters:
+        - $ref: '#/components/parameters/XRequestedWith'
+      responses:
+        '200':
+          description: ログアウト成功。ボディは空。
+        '401':
+          description: セッション無効（リフレッシュトークン Cookie なし／無効）。ボディは空。
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          description: セッション削除に失敗。
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                status: 500
+                error: Could not delete session
+
+  /api/v1/projects:
+    get:
+      tags:
+        - Projects
+      summary: プロジェクト一覧
+      description: |
+        認証済み（かつメール認証済み）ユーザーのプロジェクト一覧を返す。
+        `Authorization: Bearer <access_token>` が必要。
+      operationId: listProjects
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/XRequestedWith'
+      responses:
+        '200':
+          description: プロジェクト一覧。
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Project'
+        '401':
+          description: 未認証、またはアクセストークンが無効／非アクティブユーザー。ボディは空。
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+components:
+  parameters:
+    XRequestedWith:
+      name: X-Requested-With
+      in: header
+      required: true
+      description: CSRF 対策。`XMLHttpRequest` 固定。欠如時は 403 を返す。
+      schema:
+        type: string
+        enum:
+          - XMLHttpRequest
+        default: XMLHttpRequest
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |
+        アクセストークン。`Authorization: Bearer <token>`。
+        Rails MessageEncryptor で暗号化された user_id（subject）を含む JWT。有効期限 30 分。
+    refreshCookie:
+      type: apiKey
+      in: cookie
+      name: refresh_token
+      description: |
+        リフレッシュトークン（HttpOnly Cookie）。有効期限 24 時間。
+        jti をサーバー側（`users.refresh_jti`）で照合する。
+
+  responses:
+    Forbidden:
+      description: |
+        `X-Requested-With: XMLHttpRequest` ヘッダが欠如している（CSRF 対策）。
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            status: 403
+            error: Forbidden
+
+  schemas:
+    AuthRequest:
+      type: object
+      required:
+        - auth
+      properties:
+        auth:
+          type: object
+          required:
+            - email
+            - password
+          properties:
+            email:
+              type: string
+              format: email
+              example: user@example.com
+            password:
+              type: string
+              format: password
+              example: password
+
+    LoginResponse:
+      type: object
+      required:
+        - token
+        - expires
+        - user
+      properties:
+        token:
+          type: string
+          description: アクセストークン（JWT）。
+          example: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIuLi4ifQ.signature
+        expires:
+          type: integer
+          format: int64
+          description: アクセストークンの有効期限（UNIX エポック秒）。
+          example: 1718000000
+        user:
+          $ref: '#/components/schemas/User'
+
+    User:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: example
+
+    Project:
+      type: object
+      required:
+        - id
+        - name
+        - updatedAt
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: example project 01
+        updatedAt:
+          type: string
+          format: date-time
+          example: '2021-04-01T06:00:00.000Z'
+
+    ErrorResponse:
+      type: object
+      required:
+        - status
+        - error
+      properties:
+        status:
+          type: integer
+          example: 401
+        error:
+          type: string
+          example: Unauthorized

--- a/apidoc/openapi.yaml
+++ b/apidoc/openapi.yaml
@@ -129,6 +129,12 @@ paths:
       responses:
         '200':
           description: ログアウト成功。ボディは空。
+          headers:
+            Set-Cookie:
+              description: 失効済みのリフレッシュトークン Cookie（クライアントはこれで完了を判定できる）
+              schema:
+                type: string
+              example: refresh_token=; path=/; HttpOnly; Max-Age=0
         '401':
           description: セッション無効（リフレッシュトークン Cookie なし／無効）。ボディは空。
         '403':

--- a/apidoc/package.json
+++ b/apidoc/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "apidoc",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Stoplight Elements で jwt-api の OpenAPI 仕様書を描画する独立 Vite プロジェクト",
+  "engines": {
+    "node": ">=20.12.2"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "spectral lint openapi.yaml"
+  },
+  "dependencies": {
+    "@stoplight/elements": "^9.0.0"
+  },
+  "devDependencies": {
+    "@stoplight/spectral-cli": "^6.15.0",
+    "vite": "^7.0.0"
+  }
+}

--- a/apidoc/src/main.ts
+++ b/apidoc/src/main.ts
@@ -1,0 +1,18 @@
+// Stoplight Elements をセルフホストでバンドルする（CDN 非依存）。
+// web-components バンドルを import すると <elements-api> カスタム要素が登録される。
+import '@stoplight/elements/web-components.min.js';
+import '@stoplight/elements/styles.min.css';
+
+// openapi.yaml を Vite のアセットとして emit し、base を考慮した URL を得る。
+// 正本は apidoc/openapi.yaml のまま保持できる。
+import apiDescriptionUrl from '../openapi.yaml?url';
+
+async function mount(): Promise<void> {
+  await customElements.whenDefined('elements-api');
+  const api = document.querySelector('elements-api');
+  if (api) {
+    api.setAttribute('apiDescriptionUrl', apiDescriptionUrl);
+  }
+}
+
+void mount();

--- a/apidoc/src/vite-env.d.ts
+++ b/apidoc/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apidoc/vite.config.ts
+++ b/apidoc/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+// GitHub Pages プロジェクトサイト（https://kaki-org.github.io/jwt-api/）配信のため
+// base をリポジトリ名に合わせる。
+export default defineConfig({
+  base: '/jwt-api/',
+});


### PR DESCRIPTION
## 概要

Issue #1164 に基づき、手書き OpenAPI 仕様書を Stoplight Elements で描画し GitHub Pages へ公開する仕組みを追加します。

closes #1164

## 変更内容

- **`apidoc/`（独立 Vite ミニプロジェクト）**
  - `@stoplight/elements` を npm でセルフホストバンドル（CDN 非依存）
  - `openapi.yaml`（OpenAPI 3.1）を手書きで作成。全4エンドポイント + 認証詳細
  - `@stoplight/spectral-cli`（`spectral:oas`）で lint
- **`.github/workflows/apidoc.yml`**
  - `develop` push（`apidoc/**` 限定）+ PR でトリガー
  - `lint`（Spectral、PR でも実行）→ 成功時のみ `build` → `deploy`（Pages 公式アクション）

## OpenAPI の網羅

- `POST /api/v1/auth_token`（ログイン）
- `POST /api/v1/auth_token/refresh`（リフレッシュ、jti リプレイ検知含む）
- `DELETE /api/v1/auth_token/destroy`（ログアウト）
- `GET /api/v1/projects`（プロジェクト一覧）
- securitySchemes: Bearer（暗号化アクセストークン）+ refresh トークン Cookie
- `X-Requested-With: XMLHttpRequest` 必須ヘッダ

スキーマ・ステータスコードはコントローラ／サービス層の実挙動から起こしています。

## 検証

- ローカル: `openapi.yaml`/ワークフロー/`package.json` 構文 OK、`$ref` 7件すべて解決、`actionlint` PASS
- `npm install`/`build`/Spectral lint は CI（lint ジョブ）で実行

## 残作業（マージ後・1回のみ）

- リポジトリ Settings → Pages → Source を **GitHub Actions** に設定（手順は `apidoc/README.md`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * JWT 認証 API の対話型ドキュメントを GitHub Pages で公開
  * トークン管理とプロジェクト一覧の 4 つのエンドポイントを仕様書に記載
  * API 仕様書の自動検証とデプロイ機能を実装

<!-- end of auto-generated comment: release notes by coderabbit.ai -->