### PR TITLE
fix(apidoc): デプロイの concurrency 衝突と空白ページを修正

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -22,8 +22,11 @@ permissions:
 
 # 同一ブランチの実行をまとめる。Pages デプロイの取りこぼしを防ぐため
 # push 時は cancel-in-progress を無効化する。
+# event_name をグループに含め、PR run が push（deploy）run を
+# キャンセルしないようにする。git-pr-release の develop→master PR は
+# head.ref=develop となり push と同一グループに衝突するため、これで分離する。
 concurrency:
-  group: jwt-api-apidoc-${{ github.event.pull_request.head.ref || github.ref_name }}
+  group: jwt-api-apidoc-${{ github.event_name }}-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:

--- a/apidoc/vite.config.ts
+++ b/apidoc/vite.config.ts
@@ -4,4 +4,10 @@ import { defineConfig } from 'vite';
 // base をリポジトリ名に合わせる。
 export default defineConfig({
   base: '/jwt-api/',
+  define: {
+    // Stoplight Elements の web-components バンドルは Node グローバル `global` を
+    // 参照する。ブラウザでは未定義のため、補完しないと描画前に ReferenceError で
+    // 空白ページになる。
+    global: 'globalThis',
+  },
 });


### PR DESCRIPTION
## 背景

#1164 / #1166 でマージした API ドキュメント公開について、以下2点で公開が成立していなかった（公開URL https://kaki-org.github.io/jwt-api/ が 404）。本PRで修正する。

## 修正内容

### 1. デプロイの concurrency 衝突を修正（404 の直接原因）

PR #1166 マージ直後に git-pr-release の develop→master PR が `apidoc.yml` を `pull_request` で発火させ、`head.ref=develop` のため push（deploy）run と**同一の concurrency グループ**に衝突。`cancel-in-progress: true`（pull_request）により **deploy run がキャンセル**され、成果物が Pages に上がっていなかった。

- concurrency group に `github.event_name` を追加し、push と pull_request を別グループに分離

### 2. 空白ページを修正

Stoplight Elements の web-components バンドルが Node グローバル `global` を参照しており、ブラウザでは未定義のため描画前に ReferenceError となり空白ページになっていた。

- `vite.config.ts` に `define: { global: 'globalThis' }` を追加

## 検証

- `actionlint .github/workflows/apidoc.yml` PASS（exit=0）
- マージ後、`develop` への push で deploy が完走し https://kaki-org.github.io/jwt-api/ が描画されることを確認する

## 関連

- refs #1164, #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)