### PR TITLE
fix(apidoc): dev サーバーで空白ページになる問題を修正

### DIFF
--- a/apidoc/index.html
+++ b/apidoc/index.html
@@ -6,9 +6,10 @@
     <title>jwt-api API ドキュメント</title>
   </head>
   <body style="margin: 0; height: 100vh">
-    <!-- openapi.yaml の URL は src/main.ts が apiDescriptionUrl 属性へ注入する -->
-    <elements-api router="hash" layout="sidebar" tryItCredentialsPolicy="same-origin">
-    </elements-api>
+    <!-- <elements-api> は src/main.ts が apiDescriptionUrl を含めた属性ごと生成する。
+         属性を後付け（setAttribute）すると Stoplight Elements が loading のまま
+         固定されるため、ここには空のマウント先だけを置く。 -->
+    <div id="app" style="height: 100vh"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/apidoc/src/main.ts
+++ b/apidoc/src/main.ts
@@ -7,12 +7,13 @@ import '@stoplight/elements/styles.min.css';
 // 正本は apidoc/openapi.yaml のまま保持できる。
 import apiDescriptionUrl from '../openapi.yaml?url';
 
-async function mount(): Promise<void> {
-  await customElements.whenDefined('elements-api');
-  const api = document.querySelector('elements-api');
-  if (api) {
-    api.setAttribute('apiDescriptionUrl', apiDescriptionUrl);
-  }
-}
+// <elements-api> は DOM へ追加する前に全属性（特に apiDescriptionUrl）を確定させる。
+// マウント後に setAttribute すると Stoplight Elements が loading のまま固定されて
+// 空白ページになるため、属性をそろえてから appendChild する。
+const api = document.createElement('elements-api');
+api.setAttribute('apiDescriptionUrl', apiDescriptionUrl);
+api.setAttribute('router', 'hash');
+api.setAttribute('layout', 'sidebar');
+api.setAttribute('tryItCredentialsPolicy', 'same-origin');
 
-void mount();
+document.getElementById('app')?.appendChild(api);

--- a/apidoc/vite.config.ts
+++ b/apidoc/vite.config.ts
@@ -1,13 +1,14 @@
 import { defineConfig } from 'vite';
 
 // GitHub Pages プロジェクトサイト（https://kaki-org.github.io/jwt-api/）配信のため
-// base をリポジトリ名に合わせる。
-export default defineConfig({
-  base: '/jwt-api/',
+// build 時は base をリポジトリ名に合わせる。dev サーバーでは base を '/' にして
+// ルート（http://localhost:5173/）でそのまま開けるようにする。
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/jwt-api/' : '/',
   define: {
     // Stoplight Elements の web-components バンドルは Node グローバル `global` を
     // 参照する。ブラウザでは未定義のため、補完しないと描画前に ReferenceError で
     // 空白ページになる。
     global: 'globalThis',
   },
-});
+}));


### PR DESCRIPTION
## 概要

`apidoc/` 配下で `pnpm run dev`（`npm run dev`）してもページが空白のままになる問題を修正します。

## 原因（2点）

### ① apiDescriptionUrl の後付け setAttribute（主因）
`src/main.ts` が `<elements-api>` を **マウント後** に `setAttribute('apiDescriptionUrl', ...)` していたため、Stoplight Elements が `undefined` で loading（スピナー）を開始したまま固定され、後付け属性に反応しませんでした（ランタイムエラーは出ない）。

### ② base 設定で dev がルート配信されない
`vite.config.ts` の `base: '/jwt-api/'` が dev サーバーにも適用され、`http://localhost:5173/` がリダイレクトで空に見えていました。

## 修正内容

- `src/main.ts`: 要素を `createElement` → **全属性をセット** → `appendChild` の順に変更（マウント時に属性が揃い loading 固定を解消）。`?url` import による base 解決は維持
- `vite.config.ts`: `base` を `command === 'build' ? '/jwt-api/' : '/'` にし、dev はルート配信・build（GitHub Pages）は従来どおり
- `index.html`: `<elements-api>` 直書きをやめ、空のマウント先 `<div id="app">` のみ配置

## 検証（ヘッドレス Chromium で実描画を確認）

| 環境 | 結果 |
|---|---|
| dev（`http://localhost:5173/`） | ✅ 描画（inner=20990, Overview/Endpoints/Schemas 表示） |
| 本番 GitHub Pages 相当（静的配信・正しい MIME） | ✅ 描画（inner=21014） |

※ `vite build` の出力パスは `/jwt-api/...` のまま変わりません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * APIドキュメントの読み込み動作を改善しました。

* **Refactor**
  * APIドキュメント表示の初期化プロセスを最適化しました。
  * ビルド環境と開発環境での設定を動的に切り替えるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->