### PR TITLE
フロントエンドのアクセシビリティを改善する (#1115)

### DIFF
--- a/front/components/App/AppToaster.vue
+++ b/front/components/App/AppToaster.vue
@@ -27,6 +27,7 @@
         v-bind="attrs"
         text
         :color="toast.color"
+        aria-label="通知を閉じる"
         @click="resetToast"
       >
         Close

--- a/front/components/LoggedIn/LoggedInAppBarBreadcrumbs.vue
+++ b/front/components/LoggedIn/LoggedInAppBarBreadcrumbs.vue
@@ -2,6 +2,7 @@
   <v-breadcrumbs
     :items="items"
     class="d-block text-truncate"
+    aria-label="パンくずリスト"
   >
     <template #item="{ item }">
       <v-breadcrumbs-item>
@@ -14,7 +15,7 @@
       </v-breadcrumbs-item>
     </template>
     <template #divider>
-      <v-icon> mdi-chevron-right </v-icon>
+      <v-icon aria-hidden="true"> mdi-chevron-right </v-icon>
     </template>
   </v-breadcrumbs>
 </template>

--- a/front/components/User/UserFormEmail.vue
+++ b/front/components/User/UserFormEmail.vue
@@ -1,8 +1,11 @@
 <template>
   <v-text-field
+    id="email"
     v-model="setEmail"
     :rules="rules"
     label="メールアドレスを入力"
+    type="email"
+    autocomplete="email"
     :placeholder="placeholder ? 'your@email.com' : undefined"
     outlined
   />

--- a/front/components/User/UserFormPassword.vue
+++ b/front/components/User/UserFormPassword.vue
@@ -1,5 +1,6 @@
 <template>
   <v-text-field
+    id="password"
     v-model="setPassword"
     :rules="form.rules"
     :hint="form.hint"
@@ -7,12 +8,24 @@
     :placeholder="form.placeholder"
     :hide-details="!setValidation"
     :counter="setValidation"
-    :append-icon="toggle.icon"
     :type="toggle.type"
     outlined
     autocomplete="on"
-    @click:append="show = !show"
-  />
+  >
+    <template #append>
+      <v-icon
+        role="button"
+        tabindex="0"
+        :aria-label="toggle.ariaLabel"
+        :aria-pressed="show"
+        @click="show = !show"
+        @keydown.enter="show = !show"
+        @keydown.space.prevent="show = !show"
+      >
+        {{ toggle.icon }}
+      </v-icon>
+    </template>
+  </v-text-field>
 </template>
 
 <script>
@@ -57,7 +70,8 @@ export default {
     toggle() {
       const icon = this.show ? 'mdi-eye' : 'mdi-eye-off'
       const type = this.show ? 'text' : 'password'
-      return { icon, type }
+      const ariaLabel = this.show ? 'パスワードを隠す' : 'パスワードを表示'
+      return { icon, type, ariaLabel }
     },
   },
 }

--- a/front/pages/login.vue
+++ b/front/pages/login.vue
@@ -4,17 +4,20 @@
       <v-form
         ref="form"
         v-model="isValid"
+        aria-label="ログインフォーム"
         @submit.prevent="login"
       >
         <user-form-email v-model:email="params.auth.email" />
         <user-form-password v-model:password="params.auth.password" />
         <v-card-actions>
-          <nuxt-link
-            to="#"
-            class="body-2 text-decoration-none"
+          <!-- パスワードリセット機能は未実装。実装までは操作不可として明示する -->
+          <span
+            class="body-2 text-medium-emphasis"
+            aria-disabled="true"
+            title="準備中の機能です"
           >
             パスワードを忘れた？
-          </nuxt-link>
+          </span>
         </v-card-actions>
         <v-card-text class="px-0">
           <v-btn

--- a/front/pages/projects.vue
+++ b/front/pages/projects.vue
@@ -3,7 +3,7 @@
     <v-parallax>
       <v-img
         :src="homeImg"
-        alt="homeImg"
+        alt="プロジェクト一覧のヘッダー画像"
         :aspect-ratio="16 / 9"
         gradient="to top right, rgba(100,115,201,.33), rgba(25,32,72,.7)"
       >


### PR DESCRIPTION
## 概要

Issue #1115 の対応。コンポーネントに不足していた ARIA ラベル・セマンティック構造・alt 属性を補い、アクセシビリティを改善する。

Closes #1115

## 変更内容

| ファイル | 対応 |
|---|---|
| `AppToaster.vue` | Close ボタンに `aria-label="通知を閉じる"` |
| `UserFormPassword.vue` | `id="password"` 付与。表示切替を `#append` スロットの `v-icon` に変更し、`role="button"`・`tabindex`・状態連動 `:aria-label`（表示/隠す）・`:aria-pressed`・キーボード操作（Enter/Space）対応 |
| `UserFormEmail.vue` | `id="email"` / `type="email"` / `autocomplete="email"` 付与 |
| `LoggedInAppBarBreadcrumbs.vue` | `aria-label="パンくずリスト"`、装飾用区切りアイコンに `aria-hidden="true"` |
| `login.vue` | フォームに `aria-label="ログインフォーム"`。未実装のパスワードリセットリンク（`to="#"` の死んだリンク）を `aria-disabled` な span に置換 |
| `projects.vue` | `v-img` の `alt` を変数名 `homeImg` → 「プロジェクト一覧のヘッダー画像」 |

## 検証

- **Biome lint:** 0 errors / 新規警告 0（対象ファイルは変更前後とも同じ 4 warnings = Vue テンプレートバインディングの既知偽陽性）
- **テスト:** 17/17 パス
- **ビルド:** vite バンドル（894 modules）成功

## レビュー時の注意

1. **既存の型エラーは本対応の対象外。** 当リポジトリは Vuetify `^4.0.0` だが全コンポーネントが Vuetify 2 系記法のままで、`nuxi build` の `vue-tsc` 型チェックは**変更前から 8 ファイル・39 件のエラーで失敗**している。本変更による**新規型エラーは 0**。Vuetify 2→4 マイグレーションは別 Issue 推奨。
2. **UI 目視は未実施。** dev サーバーでの見た目確認（特に `UserFormPassword` のアイコン位置、`login.vue` の文言表示）はできていない。ブラウザでの確認を推奨。
3. ARIA ラベルは日本語直書き。将来的に i18n（`front/locales/`）へ寄せると多言語対応と一貫する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * メール入力欄にブラウザのオートコンプリート機能が対応しました。
  * パスワード表示/非表示の切り替えがキーボード操作に対応しました。

* **Bug Fixes**
  * アクセシビリティを向上：通知ダイアログ、ブレッドクラム、パスワード入力、ログインフォーム、画像代替テキストを改善しました。

* **Changes**
  * パスワードリセット機能は準備中のため、現在使用不可に設定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->