### PR TITLE
postgres:18対応でdocker-composeのDBマウント先を修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
     # ホスト側のディレクトリをコンテナで使用する
     # volumes: ホストパス（絶対 or 相対):コンテナパス(絶対)
     volumes:
-      - ./pgsql-data:/var/lib/postgresql/data
+      # postgres:18以降はPGDATAがバージョン別サブディレクトリに移動したため
+      # /var/lib/postgresql (親ディレクトリ) をマウントする
+      - ./pgsql-data:/var/lib/postgresql
     # volumes:
     #   - "pgsql-volume:/var/lib/postgresql/data"
     ports:


### PR DESCRIPTION
## 概要

postgres:18 系イメージに更新後、ローカル `docker compose up` で DB コンテナが起動しなくなる問題を修正します。

## 背景

postgres:18 以降のイメージは PGDATA をバージョン別サブディレクトリで管理する方式に変更されており、従来の `./pgsql-data:/var/lib/postgresql/data` というマウント指定では既存データディレクトリと衝突し、コンテナが起動時にエラー終了します。

## 変更内容

- `docker-compose.yml` の `db` サービスのマウント先を `/var/lib/postgresql/data` から親ディレクトリの `/var/lib/postgresql` に変更

## 動作確認

- `docker compose up -d db` でコンテナが起動することを確認
- `bundle exec rails db:prepare db:migrate` で development / test 両DBのセットアップに成功することを確認
- 既存の pg17 データは `pgsql-data.pg17.bak/`（ローカル、未コミット）に退避し、pg18 で再初期化・シード投入して動作確認済み


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * PostgreSQLのデータ保存先を更新し、コンテナ再作成後もデータが正しく保持されるよう改善しました。
  * PostgreSQL 18以降のデータディレクトリ構成に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->