### PR TITLE
usersテーブルの検索カラムにインデックスを追加

### DIFF
--- a/.steering/20260720-users-index/design.md
+++ b/.steering/20260720-users-index/design.md
@@ -1,0 +1,49 @@
+# users テーブルへのインデックス追加 — 設計
+
+## 追加するインデックス
+
+```ruby
+add_index :users, :email, unique: true, where: 'activated', name: 'index_users_on_email_activated'
+add_index :users, :refresh_jti, unique: true
+```
+
+### 1. `index_users_on_email_activated`
+
+- 対象: `users(email) WHERE activated`
+- 目的: `User.find_by(email:, activated: true)` の完全カバー + アクティブユーザー間の email 一意性保証
+- PostgreSQL の部分インデックス機能を使用。`where: 'activated'` は boolean カラムをそのまま述語に使う
+- 既存の `EmailValidator` によるアプリ層バリデーションは残す（ユーザー向けエラーメッセージのため）。
+  DB 制約は競合状態に対する最後の防波堤として機能する
+
+### 2. `index_users_on_refresh_jti`
+
+- 対象: `users(refresh_jti)`, unique
+- 目的: `RefreshToken#verify_jti?` 経路の検索高速化と JTI の一意性保証
+- `refresh_jti` は `Digest::MD5.hexdigest(SecureRandom.uuid)` 由来で衝突しない
+- PostgreSQL の UNIQUE インデックスは NULL を重複とみなさないため、
+  ログアウト済み（`refresh_jti = nil`）ユーザーが複数いても問題ない
+
+## マイグレーション
+
+`db/migrate/20260720000000_add_indexes_to_users.rb`
+
+`disable_ddl_transaction!` + `algorithm: :concurrently` は本サンプルアプリの規模では不要と判断し、
+通常のトランザクション内マイグレーションとする（既存マイグレーションの様式に合わせる）。
+
+## 既存データへの影響
+
+マイグレーション適用時、以下のデータが存在すると失敗する:
+
+- 同一 email を持つ activated=true のユーザーが 2 件以上
+- 同一 refresh_jti を持つユーザーが 2 件以上（実質発生しない）
+
+`db/seeds/development/users.rb` は `find_or_initialize_by(email:, activated: true)` を使っており
+重複を作らないため、開発環境では問題ない。マイグレーション実行前に重複チェックを行う。
+
+## テスト方針
+
+`spec/models/user_spec.rb` に DB 制約の検証を追加する:
+
+1. 未アクティベートユーザーがアクティブユーザーと同じ email で保存できること（R1 の非回帰）
+2. アクティブユーザー同士の email 重複が `ActiveRecord::RecordNotUnique` になること
+   （アプリ層バリデーションを迂回するため `insert_all` / `update_column` を使用）

--- a/.steering/20260720-users-index/requirements.md
+++ b/.steering/20260720-users-index/requirements.md
@@ -1,0 +1,54 @@
+# users テーブルへのインデックス追加 — 要件
+
+Issue: https://github.com/kaki-org/jwt-api/issues/1108
+
+## 背景
+
+`users` テーブルの頻繁に検索されるカラムにインデックスが未設定。
+`User.find_by_activated(email)` は `find_by(email:, activated: true)` を実行しており、
+ログイン (`Api::V1::AuthTokenController#login_user`) とメール重複判定 (`EmailValidator`) の
+両方で毎リクエスト呼ばれるが、対応するインデックスが存在しない。
+
+## Issue 記載内容と実装方針の差分（重要）
+
+Issue では `email` に **単純なユニークインデックス** を追加するよう記載されているが、
+これは本アプリのドメインモデルと矛盾するため、そのままは実装しない。
+
+根拠:
+
+- `app/validators/email_validator.rb:13` — `record.errors.add(attribute, :taken) if record.email_activated?`
+- `app/models/user.rb:55-58` — `email_activated?` は「自分以外の**アクティブな**同一 email ユーザー」のみ検出
+
+つまり本アプリは **「email の一意性は activated=true のユーザー間でのみ保証する」** 設計であり、
+未アクティベートユーザーは既存アクティブユーザーと同じ email を持てる。
+`email` 全体に UNIQUE 制約を張るとこの仕様が壊れ、サインアップ時に
+`ActiveRecord::RecordNotUnique` が発生する。
+
+→ 代替として **部分ユニークインデックス** `UNIQUE (email) WHERE activated` を採用する。
+これによりアプリの実際の不変条件を DB 層で保証しつつ、`find_by(email:, activated: true)` を
+完全にカバーできる。
+
+## 要件
+
+| ID | 内容 | 対応 |
+|----|------|------|
+| R1 | `find_by_activated` のクエリをインデックスで解決する | `email` への部分ユニークインデックス (`WHERE activated`) |
+| R2 | アクティブユーザー間の email 一意性を DB 層で保証する | 同上 |
+| R3 | `refresh_jti` の検証クエリを高速化し一意性を保証する | `refresh_jti` へのユニークインデックス (NULL 重複可) |
+| R4 | `activated` 単独のインデックス | **不採用**（下記参照） |
+| R5 | `ActiveRecord::Schema` のバージョンを Rails 8.1 に合わせる | **対応済み**（現状すでに `Schema[8.1]`） |
+
+### R4 を不採用とする理由
+
+`activated` は boolean（カーディナリティ 2）であり、単独インデックスはプランナに
+ほぼ選択されない。かつ実際のクエリは常に `email` との複合条件であり、
+R1 の部分インデックスが `WHERE activated` を含むため既にカバーされている。
+冗長なインデックスは書き込みコストのみ増やすため追加しない。
+
+## 受け入れ条件
+
+- [ ] マイグレーションが `dip rails db:migrate` で適用でき、`db/schema.rb` に反映される
+- [ ] 既存の RSpec が全てパスする（特に email 重複バリデーション、リフレッシュトークン系）
+- [ ] 未アクティベートユーザーがアクティブユーザーと同じ email で保存できる（回帰防止テスト）
+- [ ] アクティブユーザー同士の email 重複が DB 層で拒否される（新規テスト）
+- [ ] `dip rubocop` がパスする

--- a/.steering/20260720-users-index/tasklist.md
+++ b/.steering/20260720-users-index/tasklist.md
@@ -1,0 +1,65 @@
+# users テーブルへのインデックス追加 — タスクリスト
+
+- [x] T1: 既存データに重複（activated 同一 email / 同一 refresh_jti）が無いか確認する
+- [x] T2: マイグレーションファイル `AddIndexesToUsers` を作成する
+- [x] T3: `dip rails db:migrate` を実行し `db/schema.rb` に反映する
+- [x] T4: `spec/models/user_spec.rb` に DB 制約の検証テストを追加する
+- [x] T5: `dip rspec` を実行し全テストがパスすることを確認する
+- [x] T6: `dip rubocop` を実行し規約違反が無いことを確認する
+- [x] T7: implementation-validator による品質検証
+- [x] T8: 振り返りを本ファイルに追記する
+
+## 申し送り事項
+
+### 実装完了日
+
+2026-07-20
+
+### 検証結果
+
+| 項目 | 結果 |
+|------|------|
+| `bundle exec rspec` | 128 examples, 0 failures, 1 pending（既存の未実装 projects_spec） |
+| 追加テスト | 4 examples, 0 failures（documentation 形式で実行を確認） |
+| `bundle exec rubocop` | 64 files inspected, no offenses detected |
+| マイグレーション可逆性 | `db:rollback` → `db:migrate` の往復を実行して確認 |
+| implementation-validator | 重大な問題なし |
+
+### 計画と実績の差分
+
+1. **Issue 記載の「email への単純なユニークインデックス」は実装しなかった。**
+   `EmailValidator` / `User#email_activated?` が「email の一意性は activated=true の
+   ユーザー間でのみ保証する」設計であり、単純な UNIQUE では未アクティベートユーザーの
+   登録が `ActiveRecord::RecordNotUnique` で壊れる。部分ユニークインデックス
+   `UNIQUE (email) WHERE activated` に置き換えた。既存スペックにも
+   「アクティブユーザがいない場合の複数登録テスト」があり、この仕様を裏付けている。
+2. **`activated` 単独のインデックスは追加しなかった。** boolean でカーディナリティが 2 しかなく、
+   実クエリは常に email との複合条件のため、上記部分インデックスに包含される。
+3. **Issue 項目 4（Schema バージョンを Rails 8.1 に）は対応不要だった。** 着手時点で
+   すでに `ActiveRecord::Schema[8.1]` になっていた。
+
+### 学んだこと
+
+- `db:migrate` は `db/schema.rb` を Rails 標準の dumper 形式で再生成するため、
+  本リポジトリの規約（`# frozen_string_literal: true` + シングルクォート）が毎回失われる。
+  マイグレーション実行後は `rubocop -a db/schema.rb` を掛け、
+  `frozen_string_literal` マジックコメントは手動で復元する必要がある。
+- 本リポジトリでは `dip` が未インストールのため、`docker compose run --rm api bundle exec ...`
+  で代替した（`dip.yml` の interaction 定義と等価）。
+- PostgreSQL の UNIQUE インデックスは NULL 同士を重複と扱わないため、
+  `refresh_jti` にユニーク制約を張ってもログアウト済みユーザーが複数いて問題ない。
+
+### 次回への改善提案
+
+- Issue の記述が実装仕様と矛盾する場合があるため、DB 制約の追加時は必ず
+  該当カラムを扱うバリデータ・スコープを先に読むこと。
+- 本番相当データへ適用する際は、マイグレーション前に重複チェックを実行すること:
+  ```sql
+  SELECT email, count(*) FROM users WHERE activated GROUP BY email HAVING count(*) > 1;
+  SELECT refresh_jti, count(*) FROM users WHERE refresh_jti IS NOT NULL
+    GROUP BY refresh_jti HAVING count(*) > 1;
+  ```
+  （今回は開発 DB で実行済み・重複なしを確認。マイグレーション内での自動チェックは
+  本サンプルアプリの規模では過剰と判断し見送った）
+- PR では Issue 原文からの逸脱（部分ユニークインデックス採用）の根拠を明示し、
+  Issue 起票者と合意を取ること。

--- a/db/migrate/20260720000000_add_indexes_to_users.rb
+++ b/db/migrate/20260720000000_add_indexes_to_users.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# usersテーブルの検索カラムにインデックスを追加する
+#
+# emailは部分ユニークインデックスとする。本アプリはemailの一意性を
+# activated=trueのユーザー間でのみ保証する設計(EmailValidator参照)であり、
+# 単純なユニークインデックスでは未アクティベートユーザーの登録が壊れるため。
+class AddIndexesToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_index :users, :email, unique: true, where: 'activated',
+                              name: 'index_users_on_email_activated'
+    add_index :users, :refresh_jti, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 20_260_719_020_000) do
+ActiveRecord::Schema[8.1].define(version: 20_260_720_000_000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'pg_catalog.plpgsql'
 
@@ -26,5 +26,7 @@ ActiveRecord::Schema[8.1].define(version: 20_260_719_020_000) do
     t.string 'refresh_jti'
     t.integer 'token_version', default: 0, null: false
     t.datetime 'updated_at', null: false
+    t.index ['email'], name: 'index_users_on_email_activated', unique: true, where: 'activated'
+    t.index ['refresh_jti'], name: 'index_users_on_refresh_jti', unique: true
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -234,4 +234,42 @@ RSpec.describe User do
       end
     end
   end
+
+  describe 'DBのインデックス制約' do
+    let(:activated_user) { active_user }
+
+    context 'emailの部分ユニークインデックスを検証する場合' do
+      it '未アクティベートユーザーはアクティブユーザーと同じemailで保存できる' do
+        user = described_class.new(name: 'inactive', email: activated_user.email, password: 'password')
+        # アプリ層のバリデーションはtakenを返すが、DB層は未アクティベートの重複を許可する
+        expect { user.save(validate: false) }.to change(described_class, :count).by(1)
+      end
+
+      it 'アクティブユーザー同士のemail重複はDB層で拒否される' do
+        # アプリ層のバリデーションを迂回してDB制約のみを検証する
+        user = described_class.create!(name: 'inactive', email: 'dup-check@example.com', password: 'password')
+        described_class.where(id: user.id).update_all(activated: true)
+
+        duplicate = described_class.new(name: 'dup', email: 'dup-check@example.com', password: 'password',
+                                        activated: true)
+        expect { duplicate.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
+      end
+    end
+
+    context 'refresh_jtiのユニークインデックスを検証する場合' do
+      it '同一のrefresh_jtiは登録できない' do
+        activated_user.remember('duplicated_jti')
+        other = described_class.create!(name: 'other', email: 'other-jti@example.com', password: 'password')
+
+        expect { other.remember('duplicated_jti') }.to raise_error(ActiveRecord::RecordNotUnique)
+      end
+
+      it 'refresh_jtiがnilのユーザーは複数存在できる' do
+        described_class.create!(name: 'nil-jti-1', email: 'nil-jti-1@example.com', password: 'password')
+        expect do
+          described_class.create!(name: 'nil-jti-2', email: 'nil-jti-2@example.com', password: 'password')
+        end.to change(described_class, :count).by(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #1108

## 概要

`users` テーブルの頻繁に検索されるカラムにインデックスを追加します。

## Issue 記載内容からの逸脱（要レビュー）

Issue では `email` に **単純なユニークインデックス** を追加するよう記載されていますが、**そのままでは実装できないと判断し、部分ユニークインデックスに変更しました。**

### 根拠

本アプリは「email の一意性は `activated=true` のユーザー間でのみ保証する」設計です。

- `app/validators/email_validator.rb` — `record.errors.add(attribute, :taken) if record.email_activated?`
- `app/models/user.rb` — `email_activated?` は「自分以外の**アクティブな**同一 email ユーザー」のみ検出

既存スペックにもこの仕様を明示したテストがあります（`spec/models/user_spec.rb`「アクティブユーザがいない場合（複数登録テスト）」= 同じ email で何度でも登録可能）。

`email` 全体に UNIQUE を張るとこの仕様が壊れ、未アクティベートユーザーのサインアップが `ActiveRecord::RecordNotUnique` で落ちます。

### 対応

```ruby
add_index :users, :email, unique: true, where: 'activated',
                          name: 'index_users_on_email_activated'
```

部分ユニークインデックスにより、アプリの実際の不変条件を DB 層で保証しつつ `find_by(email:, activated: true)` を完全にカバーします。

## 変更内容

| Issue 項目 | 対応 |
|-----------|------|
| `email` にユニークインデックス | 部分ユニークインデックス `UNIQUE (email) WHERE activated` として実装 |
| `refresh_jti` にユニークインデックス | 実装（PostgreSQL は NULL 同士を重複と扱わないため、ログアウト済みユーザーが複数いても問題なし） |
| `activated` にインデックス | **不採用**。boolean でカーディナリティが 2 しかなくプランナに選択されず、実クエリは常に email との複合条件のため上記部分インデックスに包含される。書き込みコストのみ増えるため見送り |
| Schema バージョンを Rails 8.1 に | **対応不要**。着手時点ですでに `ActiveRecord::Schema[8.1]` |

## テスト

`spec/models/user_spec.rb` に DB 制約の検証を 4 件追加しました。アプリ層バリデーションを迂回（`save(validate: false)` / `update_all`）して DB 制約そのものを検証しています。

- 未アクティベートユーザーはアクティブユーザーと同じ email で保存できる（非回帰）
- アクティブユーザー同士の email 重複は DB 層で拒否される
- 同一の `refresh_jti` は登録できない
- `refresh_jti` が nil のユーザーは複数存在できる

## 検証結果

| 項目 | 結果 |
|------|------|
| `rspec` | 128 examples, 0 failures, 1 pending（既存の未実装 projects_spec） |
| `rubocop` | 64 files inspected, no offenses detected |
| マイグレーション可逆性 | `db:rollback` → `db:migrate` の往復を実行して確認 |
| 既存データ重複チェック | 開発 DB で activated 同一 email / 同一 refresh_jti ともに 0 件を確認 |

## 本番適用時の注意

マイグレーション前に重複がないことを確認してください。

```sql
SELECT email, count(*) FROM users WHERE activated GROUP BY email HAVING count(*) > 1;
SELECT refresh_jti, count(*) FROM users WHERE refresh_jti IS NOT NULL
  GROUP BY refresh_jti HAVING count(*) > 1;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTk7NVn555fhS3jWYYGj2B


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - アクティブユーザー間でメールアドレスの重複を防止し、非アクティブユーザーでは同一メールアドレスを登録できるようにしました。
  - リフレッシュトークンの識別子を一意に管理し、認証確認時の検索性能を向上しました。
  - 既存データへの制約適用と、メールアドレス・リフレッシュトークンの重複に関する動作をテストで確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->