### PR TITLE
Renovate の npm 更新に 3 日の公開待機期間を設定

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,12 @@
   "packageRules": [
     {
       "matchManagers": [
+        "npm"
+      ],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "matchManagers": [
         "bundler"
       ],
       "assignees": [


### PR DESCRIPTION
## 概要

Renovate の npm 更新に 3 日の公開待機期間（`minimumReleaseAge`）を設定します。

## 背景

公開直後の npm パッケージを Renovate が取り込むと、CI の `pnpm install --frozen-lockfile` が pnpm 11 の supply-chain policy に弾かれて失敗します。

実際に [run 30231063199](https://github.com/kaki-org/jwt-api/actions/runs/30231063199) の `vitest` ジョブが Install dependencies で失敗しました。

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 4 lockfile entries failed verification:
  @intlify/core-base@11.4.8 was published at 2026-07-26T07:34:49.000Z,
  within the minimumReleaseAge cutoff (2026-07-26T01:59:16.745Z)
  ...
```

pnpm 11 のデフォルトは公開から 24 時間。Renovate 側で 3 日待たせることで、この衝突を防ぎます。

## 変更内容

- `renovate.json` の `packageRules` に `matchManagers: ["npm"]` / `minimumReleaseAge: "3 days"` を追加

pnpm の supply-chain policy は npm 依存にのみ影響するため、bundler・github-actions・docker には適用していません。

## 補足

この設定変更は既存の失敗 run を直すものではありません。develop 側は該当バージョンの公開から 24 時間経過後に re-run するか、`front/pnpm-lock.yaml` の再生成が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HAjJCUdxi6uuvXmodiWeG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * npmパッケージの更新を公開から3日間待機してから適用するルールを追加しました。
  * 最新リリース直後の更新を避け、安定性を高めます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->