### PR TITLE
gitleaks の concurrency group をイベント種別で分離

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,8 +11,10 @@ on:
       - develop
       - main
 
+# release PR は head が develop のため、push(develop) と pull_request の run が
+# 同じグループに落ちて相互キャンセルしていた。イベント種別で名前空間を分ける。
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## 概要

Secret scan (gitleaks) ワークフローの concurrency group がイベント種別を区別しておらず、release PR で push run と pull_request run が相互キャンセルする問題を修正します。

## 問題

release PR は head ブランチが `develop` のため、同一 SHA に対して起動する 2 つの run が同じ concurrency group に落ちていました。

| run | event | 展開後の group | 結果 |
|---|---|---|---|
| 30664739316 | push (develop) | `Secret scan-develop` | **cancelled** |
| 30664742895 | pull_request (#1278) | `Secret scan-develop` | success |

`group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref \|\| github.ref_name }}` は、PR の head が `develop` のとき `head.ref` と `ref_name` が同値になります。

PR #1278 では成功側が 8 秒後に完了したため最新の check run が success になりましたが、これは完了順のたまたまです。push 側が後に完了すると同名 check `gitleaks` の最新が cancelled となり、required check にしている場合マージがブロックされます。

## 変更内容

concurrency group に `github.event_name` を含め、PR 側のキーを `head.ref` から `pull_request.number` に変更しました。これで push run と pull_request run が別の名前空間になり、同一イベント内での cancel-in-progress は従来どおり機能します。

## 検証

- `actionlint .github/workflows/gitleaks.yml` パス
- YAML パースパス
- この PR 自体の Secret scan (pull_request) が通ることで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUjztBySx2ZPdngPpY1WFc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * プッシュとプルリクエストの自動実行が互いにキャンセルされないよう、同時実行の管理を改善しました。
  * プルリクエスト番号またはブランチごとの実行単位は引き続き維持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->